### PR TITLE
add support to multiple set-cookie headers

### DIFF
--- a/src/itty-cors.ts
+++ b/src/itty-cors.ts
@@ -81,11 +81,9 @@ export const createCors = (options?: CorsOptions) => {
         'content-type': headers.get('content-type'),
       },
     })
-    if (response.headers.has('set-cookie')) {
-      responseWithNewHeaders.headers.delete('set-cookie')
-      response.headers.getAll('set-cookie')
-        .map(cookie => responseWithNewHeaders.headers.append('set-cookie', cookie))
-    }
+    responseWithNewHeaders.headers.delete('set-cookie')
+    response.headers.getAll('set-cookie')
+      .map(cookie => responseWithNewHeaders.headers.append('set-cookie', cookie))
     return responseWithNewHeaders
   }
 

--- a/src/itty-cors.ts
+++ b/src/itty-cors.ts
@@ -72,7 +72,7 @@ export const createCors = (options?: CorsOptions) => {
       return response // terminate immediately if CORS already set
     }
 
-    return new Response(body, {
+    const responseWithNewHeaders = new Response(body, {
       status,
       headers: {
         ...existingHeaders,
@@ -81,6 +81,12 @@ export const createCors = (options?: CorsOptions) => {
         'content-type': headers.get('content-type'),
       },
     })
+    if (response.headers.has('set-cookie')) {
+      responseWithNewHeaders.headers.delete('set-cookie')
+      response.headers.getAll('set-cookie')
+        .map(cookie => responseWithNewHeaders.headers.append('set-cookie', cookie))
+    }
+    return responseWithNewHeaders
   }
 
   return {


### PR DESCRIPTION
Hi,

Currently multiple `set-cookie` headers is folded into one header, eg:

`'set-cookie': 'a=aValue; Max-Age=86400; Path=/w; HttpOnly; Secure; SameSite=None, b=bValue; Max-Age=86400; Path=/w; HttpOnly; Secure; SameSite=None',`

However the correct header should be:

```
'set-cookie': [
    'a=aValue; Max-Age=86400; Path=/w; HttpOnly; Secure; SameSite=None',
    'b=bValue; Max-Age=86400; Path=/w; HttpOnly; Secure; SameSite=None'
  ],
```

I made a quick fix according to the info here https://developers.cloudflare.com/workers/runtime-apis/headers/#differences

Thanks for this awesome lib.