### PR TITLE
add websocket

### DIFF
--- a/src/itty-cors.ts
+++ b/src/itty-cors.ts
@@ -65,7 +65,7 @@ export const createCors = (options?: CorsOptions) => {
   }
 
   const corsify = (response: Response): Response => {
-    const { headers, status, body } = response
+    const { headers, status, body, webSocket } = response
     const existingHeaders = Object.fromEntries(headers)
 
     if (existingHeaders['access-control-allow-origin'] || [301, 302, 308].includes(status)) {
@@ -74,6 +74,7 @@ export const createCors = (options?: CorsOptions) => {
 
     return new Response(body, {
       status,
+      webSocket,
       headers: {
         ...existingHeaders,
         ...responseHeaders,


### PR DESCRIPTION
add `webSocket` to response, or `corsify` will fail.

```
RangeError: init["status"] must be in the range of 200 to 599, inclusive.
Web Socket request did not return status 101 Switching Protocols response with Web Socket
```