### PR TITLE
Support WebSockets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itty-cors",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "Simple (and tiny) CORS-handling for any itty-router API.  Designed on Cloudflare Workers, but works anywhere.",
   "sourceType": "module",
   "main": "./dist/itty-cors.js",

--- a/src/itty-cors.ts
+++ b/src/itty-cors.ts
@@ -1,17 +1,12 @@
 interface CorsOptions {
-  origins?: string[],
-  maxAge?: number,
-  methods?: string[],
-  headers?: any,
+  origins?: string[]
+  maxAge?: number
+  methods?: string[]
+  headers?: any
 }
 
 export const createCors = (options?: CorsOptions) => {
-  const {
-    origins = ['*'],
-    maxAge,
-    methods = ['GET'],
-    headers = {},
-  } = options
+  const { origins = ['*'], maxAge, methods = ['GET'], headers = {} } = options
 
   let allowOrigin
 
@@ -30,8 +25,9 @@ export const createCors = (options?: CorsOptions) => {
     const origin = r.headers.get('origin')
 
     // set allowOrigin globally
-    allowOrigin = (origins.includes(origin) || origins.includes('*')) &&
-      { 'Access-Control-Allow-Origin': origin }
+    allowOrigin = (origins.includes(origin) || origins.includes('*')) && {
+      'Access-Control-Allow-Origin': origin,
+    }
 
     if (r.method === 'OPTIONS') {
       // Make sure the necessary headers are present
@@ -83,6 +79,7 @@ export const createCors = (options?: CorsOptions) => {
         ...allowOrigin,
         'content-type': headers.get('content-type'),
       },
+      webSocket: response.webSocket,
     })
   }
 


### PR DESCRIPTION
The `corsify` route does not pass WebSockets through if they are defined on the response. This PR simply passes it through so it works as expected!

I published this to npm here: https://www.npmjs.com/package/@noahsaso/itty-cors